### PR TITLE
prevent de-selection of items in single-select lists

### DIFF
--- a/list.go
+++ b/list.go
@@ -83,7 +83,11 @@ func (ui *List) Mouse(dui *DUI, self *Kid, m draw.Mouse, origM draw.Mouse, orig 
 	}
 	if !r.Consumed && prevM.Buttons == 0 && m.Buttons == Button1 {
 		v := ui.Values[index]
-		v.Selected = !v.Selected
+		if ui.Multiple {
+			v.Selected = !v.Selected
+		} else {
+			v.Selected = true
+		}
 		if v.Selected && !ui.Multiple {
 			for _, vv := range ui.Values {
 				if vv != v {


### PR DESCRIPTION
I'm not sure if this behavior is intentional, so forgive me if it is, but clicking on an already-selected item in the List ui (for a non-multiple-select List) causes it to de-select, which doesn't feel normal to me. This change causes already-selected items to stay selected when clicked.